### PR TITLE
Deleting a field that doesn't exist should not fail, and should work in set

### DIFF
--- a/mockfirestore/_helpers.py
+++ b/mockfirestore/_helpers.py
@@ -77,6 +77,26 @@ class Timestamp:
         return str(self._timestamp).split('.')[1]
 
 
+def flatten_for_merge(data: Dict[str, Any], prefix: str = '') -> Dict[str, Any]:
+    """Flatten nested dicts into dot-notation keys for set(merge=True).
+
+    Firestore's set(merge=True) deep-merges at every nesting level.
+    The mock's update() already handles dot-notation keys correctly,
+    so flattening first lets the existing logic work for nested dicts.
+
+    Only plain dicts are recursed into; Firestore transform objects
+    (Sentinel, ArrayUnion, etc.) are treated as leaf values.
+    """
+    result: Dict[str, Any] = {}
+    for key, value in data.items():
+        full_key = '{}.{}'.format(prefix, key) if prefix else key
+        if isinstance(value, dict):
+            result.update(flatten_for_merge(value, prefix=full_key))
+        else:
+            result[full_key] = value
+    return result
+
+
 def get_document_iterator(document: Dict[str, Any], prefix: str = '') -> Iterator[Tuple[str, Any]]:
     """
     :returns: (dot-delimited path, value,)

--- a/mockfirestore/_helpers.py
+++ b/mockfirestore/_helpers.py
@@ -90,7 +90,7 @@ def flatten_for_merge(data: Dict[str, Any], prefix: str = '') -> Dict[str, Any]:
     result: Dict[str, Any] = {}
     for key, value in data.items():
         full_key = '{}.{}'.format(prefix, key) if prefix else key
-        if isinstance(value, dict):
+        if isinstance(value, dict) and value:
             result.update(flatten_for_merge(value, prefix=full_key))
         else:
             result[full_key] = value

--- a/mockfirestore/_transformations.py
+++ b/mockfirestore/_transformations.py
@@ -68,7 +68,10 @@ def _apply_updates(document: Dict[str, Any], data: Dict[str, Any]):
 def _apply_deletes(document: Dict[str, Any], data: List[str]):
     for key in data:
         path = key.split(".")
-        delete_by_path(document, path)
+        try:
+            delete_by_path(document, path)
+        except KeyError:
+            continue
 
 
 def _apply_arr_deletes(document: Dict[str, Any], data: Dict[str, Any]):

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -4,7 +4,8 @@ import operator
 from typing import List, Dict, Any
 from mockfirestore import NotFound
 from mockfirestore._helpers import (
-    Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path
+    Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path,
+    flatten_for_merge
 )
 from mockfirestore._transformations import apply_transformations
 
@@ -85,7 +86,7 @@ class DocumentReference:
         data['__name__'] = self.id
         if merge:
             try:
-                self.update(data)
+                self.update(flatten_for_merge(data))
             except NotFound:
                 self.set(data)
         else:

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -317,6 +317,39 @@ class TestDocumentReference(TestCase):
         doc = fs.collection("foo").document("first").get().to_dict()
         self.assertEqual(doc, {})
 
+    def test_document_update_transformerSentinelNonExistentField(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'spicy': 'tuna'}
+        }}
+        fs.collection('foo').document('first').update({"nonexistent": firestore.DELETE_FIELD})
+
+        doc = fs.collection("foo").document("first").get().to_dict()
+        self.assertEqual(doc, {'spicy': 'tuna'})
+
+    def test_document_update_transformerSentinelNonExistentNestedField(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'spicy': 'tuna'}
+        }}
+        fs.collection('foo').document('first').update({"stats.student123.field": firestore.DELETE_FIELD})
+
+        doc = fs.collection("foo").document("first").get().to_dict()
+        self.assertEqual(doc, {'spicy': 'tuna'})
+
+    def test_document_update_transformerSentinelMixedExistingAndNonExistent(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'spicy': 'tuna', 'remove_me': 'gone'}
+        }}
+        fs.collection('foo').document('first').update({
+            "remove_me": firestore.DELETE_FIELD,
+            "nonexistent": firestore.DELETE_FIELD,
+        })
+
+        doc = fs.collection("foo").document("first").get().to_dict()
+        self.assertEqual(doc, {'spicy': 'tuna'})
+
     def test_document_update_transformerArrayRemoveBasic(self):
         fs = MockFirestore()
         fs._data = {"foo": {"first": {"arr": [1, 2, 3, 4]}}}


### PR DESCRIPTION
# Fix: DELETE_FIELD on non-existent fields should be a silent no-op + work in set (merge=true)
                                                                                                                                                                                         
  ## Summary                                                                                                                                                                                

  - In real Firestore, calling update() with firestore.DELETE_FIELD on a field that doesn't exist is a silent no-op. In mock-firestore, it raised a KeyError.
  -  In real Firestore, calling set with firestore.DELETE_FIELD on a field should work. In mock-firestore, it fails
  - Wrapped delete_by_path in _apply_deletes with try/except KeyError, matching the pattern already used by _apply_arr_deletes in the same file.
  - Added 3 tests covering top-level, nested (dot-notation), and mixed existing/non-existing field deletions.

  Motivation

  Batch updates that clean up fields which may or may not exist (e.g., "stats.student123.lockdown_mode": DELETE_FIELD) would crash in tests using mock-firestore, even though they work
  fine against real Firestore. This was the only transformation type without graceful missing-field handling — ArrayRemove, Increment, and ArrayUnion all already handle it.

  ## Changes
| File | Change |
|--------|--------|
| mockfirestore/_transformations.py | Catch KeyError in _apply_deletes, skip missing fields |
| tests/test_document_reference.py | 3 new tests for DELETE_FIELD on non-existent fields  |

  ## Test plan

  - Existing test_document_update_transformerSentinel still passes (delete existing field)
  - New: DELETE_FIELD on non-existent top-level field — no error, doc unchanged
  - New: DELETE_FIELD on non-existent nested dot-notation path — no error, doc unchanged
  - New: Mixed existing + non-existing DELETE_FIELD — existing field deleted, non-existing silently ignored


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in core document mutation paths (`update` deletes and `set(..., merge=True)`), which could affect tests relying on previous strict KeyError behavior, but the change is small and well-covered by new unit tests.
> 
> **Overview**
> Aligns mock Firestore behavior with real Firestore for field deletes and merge semantics.
> 
> `firestore.DELETE_FIELD` deletions in `update()` now **silently no-op** when the target field/path does not exist (instead of raising `KeyError`). `set(..., merge=True)` now flattens nested input into dot-notation via new `flatten_for_merge()` so merge operations can apply nested transforms (including deletes) through the existing `update()` logic.
> 
> Adds unit tests covering DELETE_FIELD on missing top-level fields, missing dot-notation nested paths, and mixed existing+missing deletions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0911f4185d1ac2ec2040d0c91956a68bb090831a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->